### PR TITLE
use a newer install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qq && \
     curl -s https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run | NV=4.4.2 NP=linux-x64 OD=/usr/local sh && \
     apt-get autoremove -y
 
-RUN wget --quiet https://s3.amazonaws.com/mapbox/watchbot/linux/watchbot -O /usr/local/bin/watchbot
+RUN wget https://s3.amazonaws.com/watchbot-binaries/linux/v4.9.0/watchbot -O /usr/local/bin/watchbot
 RUN chmod +x /usr/local/bin/watchbot
 
 COPY package.json ./


### PR DESCRIPTION
Ref: https://github.com/mapbox/ecs-watchbot/blob/master/docs/upgrading-to-watchbot4.md#steps

cc/ @mapbox/platform-engine-room 